### PR TITLE
Fix MLP.make_baseline() return type

### DIFF
--- a/rtdl/modules.py
+++ b/rtdl/modules.py
@@ -562,7 +562,7 @@ class MLP(nn.Module):
                 'In this constructor, if d_layers contains more than two elements, then'
                 ' all elements except for the first and the last ones must be equal.'
             )
-        return MLP(
+        return cls(
             d_in=d_in,
             d_layers=d_layers,  # type: ignore
             dropouts=dropout,


### PR DESCRIPTION
Return object of type cls, not MLP, in MLP.make_baseline(). Otherwise, child classes inheriting from MLP constructed using the .make_baseline() method always have type MLP (instead of the type of the child class).